### PR TITLE
Docker compose file

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev"]
+

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:18
 
 WORKDIR /app
 
@@ -11,4 +11,3 @@ COPY . .
 EXPOSE 5173
 
 CMD ["npm", "run", "dev"]
-

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.15",
     "axios": "^1.6.8",
     "date-fns": "^3.6.0",
@@ -20,7 +22,6 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.2",
     "react-markdown": "^9.0.1",
-    "react-pdf": "^9.0.0",
     "react-router-dom": "^6.22.3",
     "react-syntax-highlighter": "^15.5.0",
     "socket.io-client": "^4.7.5",

--- a/client/src/components/Note.jsx
+++ b/client/src/components/Note.jsx
@@ -14,6 +14,9 @@ function Note({ note }) {
       </p>
       <p className="updatedDate">Posted {formatDate(note.updatedAt)}</p>
       <div className="noteButtons">
+        <Link to={`/notenook/postNotes/writeNote/${note._id}`}>
+          <button className="update button">Update</button>
+        </Link>
         <Link to={`/notenook/viewNote/${note._id}`}>
           <button className="view button">View</button>
         </Link>

--- a/client/src/pages/NoteNookPages/ViewNote.jsx
+++ b/client/src/pages/NoteNookPages/ViewNote.jsx
@@ -10,13 +10,6 @@ import PdfViewer from "../../components/ViewNoteComponent/PdfViewer";
 import formatDate from "../../Functions/FormatDate";
 import "../../css/ViewNote.css";
 
-import { pdfjs } from "react-pdf";
-
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  "pdfjs-dist/build/pdf.worker.min.js",
-  import.meta.url
-).toString();
-
 function ViewNote() {
   const { documentId } = useParams();
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    watch: {
+      usePolling: true,
+    },
+    host: true,
+    strictPort: true,
+    port: 5173, 
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    env_file:
+      - ./client/.env
+    volumes:
+      - ./client:/app
+    command: npm run dev
+
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./server/.env
+    volumes:
+      - ./server:/app
+    command: node server.js

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:18
 
 WORKDIR /app
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
This PR adds Docker support for the client and server apps, including a `docker-compose.yml` for easy setup. Both apps now have `.dockerignore` files to exclude `node_modules`, and Dockerfiles to define build steps. The `docker-compose.yml` sets up services, ports, and environment variables.